### PR TITLE
Javadocの説明誤り（認可判定ではなく開閉局状態の判定と誤記）を修正

### DIFF
--- a/src/main/java/nablarch/common/permission/PermissionCheckHandler.java
+++ b/src/main/java/nablarch/common/permission/PermissionCheckHandler.java
@@ -110,7 +110,7 @@ public class PermissionCheckHandler implements Handler<Object, Object> {
     }
     
     /**
-     * 開閉局状態の判定を内部リクエストIDを用いて行うか否かを設定する。
+     * 認可判定を内部リクエストIDを用いて行うか否かを設定する。
      * 
      * 明示的に設定しなかった場合のデフォルトは true (内部リクエストIDを使用する。)
      * 


### PR DESCRIPTION
[NAB-539](https://nablarch.atlassian.net/jira/software/c/projects/NAB/issues/NAB-539)でのJavadoc更新漏れに対応。

[NAB-539]: https://nablarch.atlassian.net/browse/NAB-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

取り込み漏れしているのは以下のブランチだが、これは5系向けに作られたのでdevelopブランチへマージできないことと大元のJIRAチケットはすでに過去のものになっているので新規ブランチおよびJIRAチケットで対応。

https://github.com/nablarch/nablarch-common-auth/tree/NAB-539/document-internal-request-id