### PR TITLE
Javadocの説明誤り（認可判定ではなく開閉局状態の判定と誤記）（v5）

### DIFF
--- a/src/main/java/nablarch/common/permission/PermissionCheckHandler.java
+++ b/src/main/java/nablarch/common/permission/PermissionCheckHandler.java
@@ -110,7 +110,7 @@ public class PermissionCheckHandler implements Handler<Object, Object> {
     }
     
     /**
-     * 開閉局状態の判定を内部リクエストIDを用いて行うか否かを設定する。
+     * 認可判定を内部リクエストIDを用いて行うか否かを設定する。
      * 
      * 明示的に設定しなかった場合のデフォルトは true (内部リクエストIDを使用する。)
      * 


### PR DESCRIPTION
Pull Request 7のv5系へのバックポート。

NAB-539 でのJavadoc更新漏れに対応。
